### PR TITLE
Enable strict concurrency warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,10 @@ let package = Package(
     targets: [
         .target(
             name: "Blackbird",
-            dependencies: []),
+            dependencies: [],
+            swiftSettings: [
+              .unsafeFlags(["-Xfrontend", "-warn-concurrency"])
+            ]),
         .testTarget(
             name: "BlackbirdTests",
             dependencies: ["Blackbird"]),


### PR DESCRIPTION
Hello! First-time, long-time.

You mentioned building this library for the long haul, so I wanted to suggest at least experimenting with the strict-concurrency-checking compile flag. I believe the intention is for the build warnings emitted by this flag to become errors in Swift 6. More information [here](https://forums.swift.org/t/concurrency-in-swift-5-and-6/49337#concurrency-in-swift-5-and-6-2).

(Feel free to close this PR if it's not how'd you like go about it just now; I mostly just wanted to demonstrate my suggestion if it's not something you'd come across before.)