### PR TITLE
Faster approach to check if two sets contain no common elements

### DIFF
--- a/Sources/Blackbird/Blackbird.swift
+++ b/Sources/Blackbird/Blackbird.swift
@@ -145,7 +145,7 @@ public class Blackbird {
 
         public var dataValue: Data? {
             switch self {
-                case .null:           return nil;
+                case .null:           return nil
                 case let .data(b):    return b
                 case let .integer(i): return String(i).data(using: .utf8)
                 case let .double(d):  return String(d).data(using: .utf8)
@@ -155,7 +155,7 @@ public class Blackbird {
 
         public var doubleValue: Double? {
             switch self {
-                case .null:           return nil;
+                case .null:           return nil
                 case let .double(d):  return d
                 case let .integer(i): return Double(i)
                 case let .text(s):    return Double(s)
@@ -165,7 +165,7 @@ public class Blackbird {
 
         public var intValue: Int? {
             switch self {
-                case .null:           return nil;
+                case .null:           return nil
                 case let .integer(i): return Int(i)
                 case let .double(d):  return Int(d)
                 case let .text(s):    return Int(s)
@@ -175,7 +175,7 @@ public class Blackbird {
 
         public var int64Value: Int64? {
             switch self {
-                case .null:           return nil;
+                case .null:           return nil
                 case let .integer(i): return Int64(i)
                 case let .double(d):  return Int64(d)
                 case let .text(s):    return Int64(s)
@@ -185,7 +185,7 @@ public class Blackbird {
 
         public var stringValue: String? {
             switch self {
-                case .null:           return nil;
+                case .null:           return nil
                 case let .text(s):    return s
                 case let .integer(i): return String(i)
                 case let .double(d):  return String(d)
@@ -231,10 +231,10 @@ public class Blackbird {
 public protocol BlackbirdLock: Sendable {
     func lock()
     func unlock()
-    @discardableResult func withLock<R>(_ body: () throws -> R) rethrows -> R where R : Sendable
+    @discardableResult func withLock<R>(_ body: () throws -> R) rethrows -> R where R: Sendable
 }
 extension BlackbirdLock {
-    @discardableResult public func withLock<R>(_ body: () throws -> R) rethrows -> R where R : Sendable {
+    @discardableResult public func withLock<R>(_ body: () throws -> R) rethrows -> R where R: Sendable {
         lock()
         defer { unlock() }
         return try body()

--- a/Sources/Blackbird/BlackbirdCache.swift
+++ b/Sources/Blackbird/BlackbirdCache.swift
@@ -36,7 +36,7 @@ extension Blackbird.Database {
         public let tableInvalidations: Int
     }
     
-    public func cachePerformanceMetricsByTableName() -> [String : CachePerformanceMetrics] { cache.performanceMetrics() }
+    public func cachePerformanceMetricsByTableName() -> [String: CachePerformanceMetrics] { cache.performanceMetrics() }
     public func resetCachePerformanceMetrics(tableName: String) { cache.resetPerformanceMetrics(tableName: tableName) }
     
     public func debugPrintCachePerformanceMetrics() {
@@ -54,8 +54,8 @@ extension Blackbird.Database {
     internal final class Cache: Sendable {
         private final class TableCache {
             // Cached data
-            var modelsByPrimaryKey: [Blackbird.Value : any BlackbirdModel] = [:]
-            var cachedQueries: [[Blackbird.Value] : Any] = [:]
+            var modelsByPrimaryKey: [Blackbird.Value: any BlackbirdModel] = [:]
+            var cachedQueries: [[Blackbird.Value]: Any] = [:]
             
             // Performance counters
             var hits: Int = 0
@@ -93,7 +93,7 @@ extension Blackbird.Database {
             }
         }
     
-        private let entriesByTableName = Blackbird.Locked<[String : TableCache]>([:])
+        private let entriesByTableName = Blackbird.Locked<[String: TableCache]>([:])
     
         internal func invalidate(tableName: String? = nil, primaryKeyValue: Blackbird.Value? = nil) {
             entriesByTableName.withLock {
@@ -211,7 +211,7 @@ extension Blackbird.Database {
             }
         }
         
-        internal func performanceMetrics() -> [String : CachePerformanceMetrics] {
+        internal func performanceMetrics() -> [String: CachePerformanceMetrics] {
             entriesByTableName.withLock { tableCaches in
                 tableCaches.mapValues { CachePerformanceMetrics(hits: $0.hits, misses: $0.misses, writes: $0.writes, rowInvalidations: $0.rowInvalidations, queryInvalidations: $0.queryInvalidations, tableInvalidations: $0.tableInvalidations) }
             }

--- a/Sources/Blackbird/BlackbirdChanges.swift
+++ b/Sources/Blackbird/BlackbirdChanges.swift
@@ -56,7 +56,7 @@ public extension Blackbird {
             return true
         }
         
-        if !watchedPrimaryKeys.intersection(changedPrimaryKeys).isEmpty {
+        if !watchedPrimaryKeys.isDisjoint(with: changedPrimaryKeys) {
             // Overlapping keys -- update
             return true
         }

--- a/Sources/Blackbird/BlackbirdCodable.swift
+++ b/Sources/Blackbird/BlackbirdCodable.swift
@@ -45,7 +45,7 @@ internal class BlackbirdSQLiteDecoder: Decoder {
         self.codingPath = codingPath
     }
 
-    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
         return KeyedDecodingContainer(BlackbirdSQLiteKeyedDecodingContainer<Key>(codingPath: codingPath, database: database, row: row))
     }
     public func unkeyedContainer() throws -> UnkeyedDecodingContainer { fatalError("unsupported") }
@@ -188,7 +188,7 @@ fileprivate class BlackbirdSQLiteKeyedDecodingContainer<K: CodingKey>: KeyedDeco
         return url
     }
 
-    func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T : Decodable {
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T: Decodable {
         if Data.self == T.self { return try decode(Data.self, forKey: key) as! T }
         if Date.self == T.self { return try decode(Date.self, forKey: key) as! T }
         if URL.self == T.self  { return try decode(URL.self,  forKey: key) as! T }
@@ -198,7 +198,7 @@ fileprivate class BlackbirdSQLiteKeyedDecodingContainer<K: CodingKey>: KeyedDeco
         return try T(from: BlackbirdSQLiteDecoder(database: database, row: row, codingPath: newPath))
     }
     
-    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey { fatalError("unsupported") }
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey { fatalError("unsupported") }
     func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer { fatalError("unsupported") }
     func superDecoder() throws -> Decoder { fatalError("unsupported") }
     func superDecoder(forKey key: K) throws -> Decoder { fatalError("unsupported") }

--- a/Sources/Blackbird/BlackbirdModel.swift
+++ b/Sources/Blackbird/BlackbirdModel.swift
@@ -367,7 +367,7 @@ extension BlackbirdModel {
     }
 
     private static func _sortWithPrimaryKeyValueSequence(instances: [Self], primaryKeyValues: [Blackbird.Value]) -> [Self] {
-        var primaryKeyValuesToInstances: [Blackbird.Value : Self] = [:]
+        var primaryKeyValuesToInstances: [Blackbird.Value: Self] = [:]
         for instance in instances {
             primaryKeyValuesToInstances[try! Blackbird.Value.fromAny(instance.primaryKeyValues().first!)] = instance
         }
@@ -670,7 +670,7 @@ extension BlackbirdModel {
         return try core.query(query.replacingOccurrences(of: "$T", with: table.name), arguments: arguments).map { Blackbird.ModelRow<Self>($0, table: table) }
     }
 
-    internal static func validateSchema(database: Blackbird.Database) throws -> Void {
+    internal static func validateSchema(database: Blackbird.Database) throws {
         var testRow = Blackbird.Row()
         for column in table.columns { testRow[column.name] = column.mayBeNull ? .null : column.type.defaultValue() }
         let decoder = BlackbirdSQLiteDecoder(database: database, row: testRow)

--- a/Sources/Blackbird/BlackbirdModelStructuredQuerying.swift
+++ b/Sources/Blackbird/BlackbirdModelStructuredQuerying.swift
@@ -72,7 +72,7 @@ fileprivate struct DecodedStructuredQuery: Sendable {
     let tableName: String
     let cacheKey: [Blackbird.Value]?
     
-    init<T: BlackbirdModel>(operation: String = "SELECT * FROM", selectColumnSubset: [PartialKeyPath<T>]? = nil,  matching: BlackbirdModelColumnExpression<T>? = nil, updating: [PartialKeyPath<T> : Sendable] = [:], orderBy: [BlackbirdModelOrderClause<T>] = [], limit: Int? = nil) {
+    init<T: BlackbirdModel>(operation: String = "SELECT * FROM", selectColumnSubset: [PartialKeyPath<T>]? = nil, matching: BlackbirdModelColumnExpression<T>? = nil, updating: [PartialKeyPath<T>: Sendable] = [:], orderBy: [BlackbirdModelOrderClause<T>] = [], limit: Int? = nil) {
         let table = SchemaGenerator.shared.table(for: T.self)
         var clauses: [String] = []
         var arguments: [Blackbird.Value] = []
@@ -298,13 +298,13 @@ extension BlackbirdModel {
     /// // Equivalent to:
     /// // "UPDATE Post SET title = 'Hi' WHERE id = 123"
     /// ```
-    public static func update(in database: Blackbird.Database, set changes: [BlackbirdColumnKeyPath : Sendable], matching: BlackbirdModelColumnExpression<Self>) async throws {
+    public static func update(in database: Blackbird.Database, set changes: [BlackbirdColumnKeyPath: Sendable], matching: BlackbirdModelColumnExpression<Self>) async throws {
         if changes.isEmpty { return }
         try await updateIsolated(in: database, core: database.core, set: changes, matching: matching)
     }
 
     /// Synchronous version of ``update(in:set:matching:)`` for use when the database actor is isolated within calls to ``Blackbird/Database/transaction(_:)`` or ``Blackbird/Database/cancellableTransaction(_:)``.
-    public static func updateIsolated(in database: Blackbird.Database, core: isolated Blackbird.Database.Core, set changes: [BlackbirdColumnKeyPath : Sendable], matching: BlackbirdModelColumnExpression<Self>) throws {
+    public static func updateIsolated(in database: Blackbird.Database, core: isolated Blackbird.Database.Core, set changes: [BlackbirdColumnKeyPath: Sendable], matching: BlackbirdModelColumnExpression<Self>) throws {
         if database.options.contains(.readOnly) { fatalError("Cannot update BlackbirdModels in a read-only database") }
         if changes.isEmpty { return }
         let table = Self.table
@@ -351,7 +351,7 @@ extension BlackbirdModel {
     }
 }
 
-//MARK: - Where-expression DSL
+// MARK: - Where-expression DSL
 
 /*
     This is what enables the "matching:" parameters with structured properties like this:

--- a/Sources/Blackbird/BlackbirdPerformanceLogger.swift
+++ b/Sources/Blackbird/BlackbirdPerformanceLogger.swift
@@ -130,7 +130,7 @@ extension Blackbird {
         /// ```swift
         /// let spid = perLogger.signpostId(for: .execute)
         /// ```
-        func signpostId(for sp:Signpost) -> OSSignpostID {
+        func signpostId(for sp: Signpost) -> OSSignpostID {
             // Force unwrap because if we don't have a match we're in big trouble and should crash.
             return spidMap[sp]!
         }

--- a/Sources/Blackbird/BlackbirdSchema.swift
+++ b/Sources/Blackbird/BlackbirdSchema.swift
@@ -199,7 +199,7 @@ extension Blackbird {
         internal let emptyInstance: (any BlackbirdModel)?
         
         private static let resolvedTablesWithDatabases = Locked([Table: Set<Database.InstanceID>]())
-        private static let resolvedTableNamesInDatabases = Locked([Database.InstanceID : Set<String>]())
+        private static let resolvedTableNamesInDatabases = Locked([Database.InstanceID: Set<String>]())
         
         public init(name: String, columns: [Column], primaryKeyColumnNames: [String] = ["id"], indexes: [Index] = [], emptyInstance: any BlackbirdModel) {
             if columns.isEmpty { fatalError("No columns specified") }
@@ -218,7 +218,7 @@ extension Blackbird {
         }
         
         // Enable "upsert" (REPLACE INTO) behavior ONLY for primary-key conflicts, not any other UNIQUE constraints
-        private static func generateUpsertClause(columnNames: [String], primaryKeyColumnNames: [String])-> String {
+        private static func generateUpsertClause(columnNames: [String], primaryKeyColumnNames: [String]) -> String {
             let upsertReplacements = columnNames.filter { !primaryKeyColumnNames.contains($0) }.map { "`\($0)` = excluded.`\($0)`" }
             return upsertReplacements.isEmpty ? "" : "ON CONFLICT (`\(primaryKeyColumnNames.joined(separator: "`,`"))`) DO UPDATE SET \(upsertReplacements.joined(separator: ","))"
         }
@@ -371,7 +371,7 @@ internal extension String {
 internal final class SchemaGenerator: Sendable {
     internal static let shared = SchemaGenerator()
     
-    let tableCache = Blackbird.Locked<[ObjectIdentifier : Blackbird.Table]>([:])
+    let tableCache = Blackbird.Locked<[ObjectIdentifier: Blackbird.Table]>([:])
     
     internal func table<T: BlackbirdModel>(for type: T.Type) -> Blackbird.Table {
         tableCache.withLock { cache in
@@ -491,7 +491,7 @@ internal final class SchemaGenerator: Sendable {
 fileprivate struct EmptyDecoder: Decoder {
     var codingPath: [CodingKey] = []
     var userInfo: [CodingUserInfoKey: Any] = [:]
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey { KeyedDecodingContainer(EmptyKeyedDecodingContainer<Key>()) }
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey { KeyedDecodingContainer(EmptyKeyedDecodingContainer<Key>()) }
     func unkeyedContainer() throws -> UnkeyedDecodingContainer { EmptyUnkeyedDecodingContainer() }
     func singleValueContainer() throws -> SingleValueDecodingContainer { EmptySingleValueDecodingContainer() }
 }

--- a/Sources/Blackbird/BlackbirdSwiftUI.swift
+++ b/Sources/Blackbird/BlackbirdSwiftUI.swift
@@ -276,7 +276,7 @@ extension Blackbird {
     }
 
     /// Used in Blackbird's SwiftUI primitives.
-    public class ModelUpdater<T: BlackbirdModel>: @unchecked Sendable  { // unchecked due to internal locking
+    public class ModelUpdater<T: BlackbirdModel>: @unchecked Sendable { // unchecked due to internal locking
         @Binding public var instance: T?
 
         private let resultPublisher: CachedResultPublisher<T?>


### PR DESCRIPTION
`Set.isDisjoint` has better performance compared to `Set.intersection`.  The latter first computes the intersection between two sets by creating a new set containing the common elements whereas `Set.isDisjoint` will exit as soon as a common element is found, making it faster. 🛫

I've also made some small syntax (mostly spaces) adjustments. Keep or discard them at your will 😅