### PR TITLE
Fix queries made with named arguments to be passed to Database.Core correctly

### DIFF
--- a/Sources/Blackbird/BlackbirdDatabase.swift
+++ b/Sources/Blackbird/BlackbirdDatabase.swift
@@ -477,7 +477,7 @@ extension Blackbird {
 
         @discardableResult public func query(_ query: String, arguments: [Sendable]) async throws -> [Blackbird.Row] { return try await core.query(query, arguments) }
 
-        @discardableResult public func query(_ query: String, arguments: [String: Sendable]) async throws -> [Blackbird.Row] { return try await core.query(query, arguments) }
+        @discardableResult public func query(_ query: String, arguments: [String: Sendable]) async throws -> [Blackbird.Row] { return try await core.query(query, arguments: arguments) }
 
         public func setArtificialQueryDelay(_ delay: TimeInterval?) async { await core.setArtificialQueryDelay(delay) }
 


### PR DESCRIPTION
Fixes issue #23 by adding the necessary `arguments:` label on the second parameter of the function call into Database.Core.