### PR TITLE
Add ability to backup the database

### DIFF
--- a/Tests/BlackbirdTests/BlackbirdTests.swift
+++ b/Tests/BlackbirdTests/BlackbirdTests.swift
@@ -1286,6 +1286,9 @@ final class BlackbirdTestTests: XCTestCase, @unchecked Sendable {
         let modelsInBackupDb = try await TestModel.read(from: backupDb)
 
         XCTAssert(modelsInDb == modelsInBackupDb)
+
+        await db.close()
+        await backupDb.close()
     }
 
 

--- a/Tests/BlackbirdTests/BlackbirdTests.swift
+++ b/Tests/BlackbirdTests/BlackbirdTests.swift
@@ -1264,6 +1264,30 @@ final class BlackbirdTestTests: XCTestCase, @unchecked Sendable {
 //        }
     }
 
+    func testBackup() async throws {
+        let db = try Blackbird.Database(path: sqliteFilename)
+        for i in 0..<1000 {
+            try await TestModel(id: Int64(i), title: TestData.randomTitle, url: TestData.randomURL).write(to: db)
+        }
+        let backupFilePath = sqliteFilename + ".backup"
+        print("Creating backup at \(backupFilePath)")
+        
+        defer {
+            for path in Blackbird.Database.allFilePaths(for: backupFilePath) {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+        
+        try await db.core.backup(to: backupFilePath, pagesPerStep: 100, printProgress: true)
+        
+        let backupDb = try Blackbird.Database(path: backupFilePath)
+         
+        let modelsInDb = try await TestModel.read(from: db)
+        let modelsInBackupDb = try await TestModel.read(from: backupDb)
+
+        XCTAssert(modelsInDb == modelsInBackupDb)
+    }
+
 
 /* Tests duplicate-index detection. Throws fatal error on success.
     func testDuplicateIndex() async throws {


### PR DESCRIPTION
SQLite provides an [Online Backup API](https://www.sqlite.org/backup.html) to make a copy of the whole database without closing it.

This pull request adds the method `backup` to `Blackbird.Database` to use said API in a simple manner.