### PR TITLE
Improve cleanup for database files after running tests

### DIFF
--- a/Tests/BlackbirdTests/BlackbirdTests.swift
+++ b/Tests/BlackbirdTests/BlackbirdTests.swift
@@ -63,7 +63,11 @@ final class BlackbirdTestTests: XCTestCase, @unchecked Sendable {
     }
 
     override func tearDownWithError() throws {
-        if sqliteFilename != "", sqliteFilename != ":memory:", FileManager.default.fileExists(atPath: sqliteFilename) { try FileManager.default.removeItem(atPath: sqliteFilename) }
+        if sqliteFilename != "", sqliteFilename != ":memory:", FileManager.default.fileExists(atPath: sqliteFilename) {
+            for path in Blackbird.Database.allFilePaths(for: sqliteFilename) {
+                try FileManager.default.removeItem(atPath: path)
+            }
+        }
     }
 
     // Use XCTAssert and related functions to verify your tests produce the correct results.

--- a/Tests/BlackbirdTests/BlackbirdTests.swift
+++ b/Tests/BlackbirdTests/BlackbirdTests.swift
@@ -65,7 +65,7 @@ final class BlackbirdTestTests: XCTestCase, @unchecked Sendable {
     override func tearDownWithError() throws {
         if sqliteFilename != "", sqliteFilename != ":memory:", FileManager.default.fileExists(atPath: sqliteFilename) {
             for path in Blackbird.Database.allFilePaths(for: sqliteFilename) {
-                try FileManager.default.removeItem(atPath: path)
+                try? FileManager.default.removeItem(atPath: path)
             }
         }
     }


### PR DESCRIPTION
Running the unit tests creates a database file as well as "-shm" and "-wal" files. While the main database file is deleted in `tearDownWithError`, the other two remain in the temporary directory.

This pull request ensures that all three files are removed in `tearDownWithError`.