### PR TITLE
Improve backup error handling

### DIFF
--- a/Sources/Blackbird/BlackbirdDatabase.swift
+++ b/Sources/Blackbird/BlackbirdDatabase.swift
@@ -898,10 +898,14 @@ extension Blackbird {
                         let remainingPages = sqlite3_backup_remaining(backup)
                         let totalPages = sqlite3_backup_pagecount(backup)
                         let backedUpPages = totalPages - remainingPages
-                        print("Backed up \(backedUpPages) pages of \(totalPages)\n")
+                        print("Backed up \(backedUpPages) pages of \(totalPages)")
                     }
                     
                     await Task.yield()
+                }
+                
+                guard stepResult == SQLITE_DONE else {
+                    throw Blackbird.Database.Error.backupError(description: errorDesc(targetDbHandle))
                 }
 
                 sqlite3_backup_finish(backup)


### PR DESCRIPTION
The recently added `Database.backup()` method fails to verify that the result of the last `sqlite3_backup_step` is `SQLITE_DONE`. If an error occurs while creating the backup (e.g. some IO error), the result might not be `SQLITE_DONE`.

This pull request adds this check and throws if the result is not `SQLITE_DONE`. It also ensures that the backup process is ended and the database connection is closed if an error occurs at any point. 

However, I've not been able to actually **make** the backup fail, so I can't verify that the final check yields the correct error message. 

Apologies for the oversight in the previous pull request.