### PR TITLE
Use `@Entry` macro for environment value

### DIFF
--- a/Sources/Blackbird/BlackbirdSwiftUI.swift
+++ b/Sources/Blackbird/BlackbirdSwiftUI.swift
@@ -37,16 +37,9 @@ import SwiftUI
 // Required to use with the @StateObject wrapper
 extension Blackbird.Database: ObservableObject { }
 
-struct EnvironmentBlackbirdDatabaseKey: EnvironmentKey {
-    static let defaultValue: Blackbird.Database? = nil
-}
-
 extension EnvironmentValues {
     /// The ``Blackbird/Database`` to use with `@BlackbirdLive…` property wrappers.
-    public var blackbirdDatabase: Blackbird.Database? {
-        get { self[EnvironmentBlackbirdDatabaseKey.self] }
-        set { self[EnvironmentBlackbirdDatabaseKey.self] = newValue }
-    }
+    @Entry public var blackbirdDatabase: Blackbird.Database? = nil
 }
 
 extension Blackbird {


### PR DESCRIPTION
Simplifies the EnvironmentKey boilerplate code with the [`@Entry` macro](https://developer.apple.com/documentation/swiftui/entry()).