### PR TITLE
Fix up Package.swift and GitHub Actions

### DIFF
--- a/.github/workflows/RunTests.yaml
+++ b/.github/workflows/RunTests.yaml
@@ -15,16 +15,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
-      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-writing-an-environment-variable-to-github_env
-      # get Package.swift file contents, find line with swift-tools-version, get string after :, trim whitespaces from string
-      - name: Get swift version from Package.swift file
-        shell: bash
-        run: |
-          echo "swift-tools-version=$( cat ./Package.swift | grep swift-tools-version | cut -d ":" -f2 | sed -e 's/^[[:space:]]*//' )" >> $GITHUB_ENV
-      - uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: "${{ env.swift-tools-version }}"
+      - uses: actions/checkout@v6
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
       - name: Verify swift version
         run: swift --version
       - name: Build

--- a/Package.swift
+++ b/Package.swift
@@ -8,23 +8,24 @@ let package = Package(
         .macOS(.v12),
         .iOS(.v15),
         .watchOS(.v8),
-        .tvOS(.v15),
+        .tvOS(.v15)
     ],
     products: [
         .library(
             name: "Blackbird",
-            targets: ["Blackbird"]),
+            targets: ["Blackbird"]
+        )
     ],
-    dependencies: [
-    ],
+    dependencies: [],
     targets: [
         .target(
             name: "Blackbird",
-            dependencies: [],
+            dependencies: []
         ),
         .testTarget(
             name: "BlackbirdTests",
-            dependencies: ["Blackbird"]),
+            dependencies: ["Blackbird"]
+        )
     ],
     swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
Hi Marco!

I happened to be browsing GitHub this morning, and noticed that Blackbird hadn't had a successful GitHub Actions build in a bit, so I figured I would take a peek and try to fix it.

# Summary of changes

### Switches from `setup-swift` to the version of Swift that is included in Xcode
This change was implemented due to the possible [unmaintained status of setup-swift](https://github.com/swift-actions/setup-swift/issues/786). Currently, Github includes [multiple versions](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md) of Xcode 26 in the `macos-latest` runner image. We stick with the default, at least for now. Using the version of Xcode that ships on the runner image means we don't need to spend the time installing a separate Swift, which speeds up CI time. As the Swift version is no longer being pulled from Package.swift, I've removed the Actions step that greps for it. Additionally, we upgrade to `actions/checkout@v6`.

### Cleanup of Package.swift
Package.swift had a few syntax issues that were throwing errors during compile with Swift 6, mostly regarding trailing commas. I've updated the syntax to reflect the new, stricter syntax requirements. A few test runs on my end show no issues, however, I understand that my changes to the formatting may not be to your preference.

Overall, this is a super minor, but functional PR that should help out with the development of Blackbird by ensuring that Github Actions continues to run the tests on each commit and PR.