### PR TITLE
Remove unnecessary try from primaryKeyValues() call sites

### DIFF
--- a/Sources/Blackbird/BlackbirdCache.swift
+++ b/Sources/Blackbird/BlackbirdCache.swift
@@ -376,13 +376,13 @@ extension Blackbird.Database {
 extension BlackbirdModel {
     internal func _saveCachedInstance(for database: Blackbird.Database) {
         let cacheLimit = Self.cacheLimit
-        if cacheLimit > 0, let pkValues = try? self.primaryKeyValues(), pkValues.count == 1, let pk = try? Blackbird.Value.fromAny(pkValues.first!) {
+        if cacheLimit > 0, case let pkValues = self.primaryKeyValues(), pkValues.count == 1, let pk = try? Blackbird.Value.fromAny(pkValues.first!) {
             database.cache.writeModel(tableName: Self.tableName, primaryKey: pk, instance: self, entryLimit: cacheLimit)
         }
     }
 
     internal func _deleteCachedInstance(for database: Blackbird.Database) {
-        if Self.cacheLimit > 0, let pkValues = try? self.primaryKeyValues(), pkValues.count == 1, let pk = try? Blackbird.Value.fromAny(pkValues.first!) {
+        if Self.cacheLimit > 0, case let pkValues = self.primaryKeyValues(), pkValues.count == 1, let pk = try? Blackbird.Value.fromAny(pkValues.first!) {
             database.cache.deleteModel(tableName: Self.tableName, primaryKey: pk)
         }
     }

--- a/Sources/Blackbird/BlackbirdObservation.swift
+++ b/Sources/Blackbird/BlackbirdObservation.swift
@@ -118,7 +118,7 @@ public final class BlackbirdModelQueryObserver<T: BlackbirdModel, R: Sendable> {
 extension BlackbirdModel {
     public typealias Observer = BlackbirdModelObserver<Self>
     
-    public var observer: Observer { Observer(multicolumnPrimaryKey: try! primaryKeyValues()) }
+    public var observer: Observer { Observer(multicolumnPrimaryKey: primaryKeyValues()) }
 }
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)

--- a/Sources/Blackbird/BlackbirdSwiftUI.swift
+++ b/Sources/Blackbird/BlackbirdSwiftUI.swift
@@ -199,7 +199,7 @@ extension Blackbird {
 
     public init(_ instance: T, updatesEnabled: Bool = true) {
         _instance = State(initialValue: instance)
-        instanceObserver = BlackbirdModelInstanceChangeObserver<T>(primaryKeyValues: try! instance.primaryKeyValues().map { try! Blackbird.Value.fromAny($0) })
+        instanceObserver = BlackbirdModelInstanceChangeObserver<T>(primaryKeyValues: instance.primaryKeyValues().map { try! Blackbird.Value.fromAny($0) })
         instanceObserver.updatesEnabled = updatesEnabled
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to 7b2c93c ("Removed unused throws") which made `primaryKeyValues()` non-throwing
- That commit left behind `try!` and `try?` at four call sites, producing compiler warnings:
  - `BlackbirdObservation.swift:121` — `try!`
  - `BlackbirdCache.swift:379` — `try?`
  - `BlackbirdCache.swift:385` — `try?`
  - `BlackbirdSwiftUI.swift:202` — `try!`
- Removed the redundant `try` operators from `primaryKeyValues()` while keeping `try!`/`try?` on `Blackbird.Value.fromAny()`, which still throws

## Test plan
- [x] `swift build` completes with zero warnings
- [x] `swift test` passes all 27 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)